### PR TITLE
Improve login page design

### DIFF
--- a/FE/app/globals.css
+++ b/FE/app/globals.css
@@ -309,3 +309,33 @@
 .date-header hr.divider-gray {
   display: none;
 }
+
+/* -----------------------------------------------
+   Custom Google-style gradient and button styles
+   ----------------------------------------------- */
+
+.bg-google-gradient {
+  background: linear-gradient(135deg, #4285f4, #db4437, #f4b400, #0f9d58);
+}
+
+.btn-google {
+  background: linear-gradient(90deg, #4285f4, #db4437, #f4b400, #0f9d58);
+  color: white;
+  font-weight: 700;
+  padding: 0.75rem 2rem;
+  border-radius: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.btn-google:hover {
+  filter: brightness(1.05);
+}
+
+.btn-google:active {
+  transform: scale(0.95);
+  filter: brightness(1.15);
+}
+

--- a/FE/app/page.tsx
+++ b/FE/app/page.tsx
@@ -81,7 +81,7 @@ export default function Page() {
     getToken();
   }, [router]);
   return (
-    <div className="relative flex justify-center items-center h-screen overflow-hidden bg-black">
+    <div className="relative flex justify-center items-center h-screen overflow-hidden bg-google-gradient">
       {/* 별만 있는 레이어 */}
       <Stars count={150} />
 

--- a/FE/components/login/LoginButton.tsx
+++ b/FE/components/login/LoginButton.tsx
@@ -7,9 +7,9 @@ import { Button } from "@/components/ui/button";
 export function LoginButton() {
   return (
     <div>
-      <Button variant="outline" className="flex max-w-min py-7 px-10 cursor-pointer hover:bg-gray-300">
-        <Link className="flex flex-row justify-center items-center gap-2 p-2" href="http://localhost:8000/auth/google">
-          <img src="./googleLogo.png" className="flex w-10" />
+      <Button asChild className="btn-google">
+        <Link className="flex flex-row items-center" href="http://localhost:8000/auth/google">
+          <img src="./googleLogo.png" className="w-6" />
           Google 로그인
         </Link>
       </Button>


### PR DESCRIPTION
## Summary
- add Google-inspired gradient and button styles
- restyle login button with new gradient
- apply gradient background to login page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c29b868048322abc681f6c7f86cdc