### PR TITLE
Access Token 미전달로 인한 401 에러 수정

### DIFF
--- a/BE/app/core/exception_handlers.py
+++ b/BE/app/core/exception_handlers.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.core.exceptions import BaseCustomException
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ async def custom_http_exception_handler(request: Request, exc: BaseCustomExcepti
             "code": exc.error_code,
             "status": exc.status_code
         },
-        "timestamp": None,
+        "timestamp": datetime.now().isoformat(),
         "path": request.url.path,
         "method": request.method
     }

--- a/BE/app/router/notification.py
+++ b/BE/app/router/notification.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, Request
 from typing import List
 
 from app.core.security import verify_token_and_get_token_data
+from app.core.exceptions import PermissionDeniedError
 from app.service.notification import NotificationService
 from app.schema.notification.response import NotificationSchema
 
@@ -47,7 +48,11 @@ def create_push_message(nickname: str, content: str, file_url: str) -> str:
         return f"{nickname}: {clean_content}"
 
 @router.get("/{user_id}", response_model=List[NotificationSchema])
-async def get_notifications(user_id: str):
+async def get_notifications(user_id: str, token_data = Depends(verify_token_and_get_token_data)):
+    # 토큰의 user_id와 요청한 user_id가 일치하는지 확인
+    if token_data["user_id"] != user_id:
+        raise PermissionDeniedError("본인의 알림만 조회할 수 있습니다")
+
     notifications = service.get_notifications(user_id)
     return [NotificationSchema.from_domain(n) for n in notifications]
 

--- a/BE/app/router/sse.py
+++ b/BE/app/router/sse.py
@@ -76,7 +76,7 @@ async def send_sse_notification(workspace_id: str, payload: dict):
         await queue.put(payload)
 
 @router.post("/sse/notifications/{workspace_id}")
-async def asdf(workspace_id: str, request: Request):
+async def asdf(workspace_id: str, request: Request, token_data = Depends(verify_token_and_get_token_data)):
     print("\n\n\nin asdf")
     payload = await request.json()
     print(payload)

--- a/FE/components/sse/SSEListener.tsx
+++ b/FE/components/sse/SSEListener.tsx
@@ -22,42 +22,89 @@ export function SSEListener() {
   const refreshTabs = useTabStore((s) => s.refreshTabs);
 
   useEffect(() => {
+    const accessToken = localStorage.getItem("access_token");
+    if (!accessToken) {
+      console.warn("No access token available for SSE.");
+      return;
+    }
+
     const url = `${BASE}/api/sse/notifications?workspaceId=${workspaceId}`;
-    const es = new EventSource(url);
+    const controller = new AbortController();
 
-    // SSE 연결
-    es.onopen = () => console.log("SSE: 연결");
+    async function connectSSE() {
+      try {
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Accept': 'text/event-stream',
+          },
+          signal: controller.signal,
+        });
 
-    // SSE 오류
-    es.onerror = () => {
-      console.log("SSE: 연결 끊김");
-      es.close();
-    } 
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
 
-    // 새로운 메시지 도착함 (new_message 타입)
-    es.addEventListener("new_message", (e: MessageEvent) => {
-      const p: SSEPayload = JSON.parse(e.data);
-      console.log("SSE: 새 메세지 도착");
-      if (p.tab_id.toString() !== tabId) {
-        incUnread(p.tab_id);
+        console.log("SSE: 연결");
+
+        const reader = response.body?.getReader();
+        const decoder = new TextDecoder();
+
+        if (!reader) return;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value);
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.startsWith('event:')) {
+              const eventType = line.substring(6).trim();
+              continue;
+            }
+
+            if (line.startsWith('data:')) {
+              const data = line.substring(5).trim();
+
+              if (data === 'p') { // ping
+                console.log("SSE: 유지 ping");
+                continue;
+              }
+
+              try {
+                const payload: SSEPayload = JSON.parse(data);
+
+                if (payload.type === 'new_message') {
+                  console.log("SSE: 새 메세지 도착");
+                  if (payload.tab_id.toString() !== tabId) {
+                    incUnread(payload.tab_id);
+                  }
+                } else if (payload.type === 'invited_to_tab') {
+                  console.log("SSE: 새로운 탭 초대");
+                  addInvitedTab(payload.tab_id);
+                  refreshTabs();
+                }
+              } catch (e) {
+                console.error("SSE data parse error:", e);
+              }
+            }
+          }
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          console.log("SSE: 연결 끊김", error);
+        }
       }
-    });
+    }
 
-    // SSE 유지를 위한 핑
-    es.addEventListener("ping", () => {
-      console.log("SSE: 유지 ping");
-    });
+    connectSSE();
 
-    // 새로운 탭에 초대됨
-    es.addEventListener("invited_to_tab", (e: MessageEvent) => {
-      const p: SSEPayload = JSON.parse(e.data);
-      console.log("SSE: 새로운 탭 초대");
-      addInvitedTab(p.tab_id);
-      refreshTabs(); // 사이드바 갱신
-    });
-
-    return () => es.close();
-  }, [workspaceId, incUnread, refreshTabs]);
+    return () => {
+      controller.abort();
+    };
+  }, [workspaceId, incUnread, refreshTabs, addInvitedTab, tabId]);
 
   return null;
 }


### PR DESCRIPTION
## 📌 작업 내용 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요.

* notification SSE 요청 시 Access Token을 전달하지 않고 있어서 401 에러가 발생하여 아래와 같이 수정했습니다. 
  - Front:  EventSource가 Authorization 헤더를 지원하지 않아 인증 토큰 전달이 불가능했기 때문에 fetch + ReadableStream 방식으로 변경하여 Bearer 토큰을 헤더로 전달하도록 수정
  - Back: notification SSE 요청 시 전달받은 Access Token 확인
---

## ✅ 체크리스트

- [x] 커밋 메세지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트 및 UI/UX를 확인했습니다.



